### PR TITLE
Pinned client lib version to avoid intermittent error with 2.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "express-handlebars": "^3.0.0",
     "express-session": "^1.15.6",
     "node-fetch": "^2.1.2",
-    "openid-client": "^1.20.0"
+    "openid-client": "1.20.0"
   }
 }


### PR DESCRIPTION
We were seeing a consistent "client authentication failed" when exchanging the authorization code for an access token.  Pinning the version for now.